### PR TITLE
Puppet certname & automatic certificate signing support.

### DIFF
--- a/loom/files/puppet/puppet.conf
+++ b/loom/files/puppet/puppet.conf
@@ -10,9 +10,11 @@ pluginsync = true
 environment = %(environment)s
 
 [master]
+certname = %(certname)s
+dns_alt_names = %(dns_alt_names)s
 # These are needed when the puppetmaster is run by passenger
 # and can safely be removed if webrick is used.
-ssl_client_header = SSL_CLIENT_S_DN 
+ssl_client_header = SSL_CLIENT_S_DN
 ssl_client_verify_header = SSL_CLIENT_VERIFY
 
 [agent]

--- a/loom/files/puppet/puppet.conf
+++ b/loom/files/puppet/puppet.conf
@@ -10,6 +10,7 @@ pluginsync = true
 environment = %(environment)s
 
 [master]
+autosign = /etc/puppet/autosign.conf
 certname = %(certname)s
 dns_alt_names = %(dns_alt_names)s
 # These are needed when the puppetmaster is run by passenger

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -48,7 +48,7 @@ def update_configs():
     put(StringIO(current_role()), '/etc/puppet/role', use_sudo=True)
 
     # Allow the puppet master to automatically sign certificates
-    if env.get('loom_autosign') == 'true':
+    if env.get('loom_autosign'):
         put(StringIO('*'), '/etc/puppet/autosign.conf', use_sudo=True)
     else:
         put(StringIO(''), '/etc/puppet/autosign.conf', use_sudo=True)

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -47,6 +47,9 @@ def update_configs():
     # working
     put(StringIO(current_role()), '/etc/puppet/role', use_sudo=True)
 
+    # Allow the puppet master to automatically sign certificates
+    put(StringIO('*'), '/etc/puppet/autosign.conf', use_sudo=True)
+
     # Upload Puppet configs
     upload_template(os.path.join(files_path, 'puppet/puppet.conf'), '/etc/puppet/puppet.conf', {
         'server': get_puppetmaster_host() or '',

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -48,7 +48,10 @@ def update_configs():
     put(StringIO(current_role()), '/etc/puppet/role', use_sudo=True)
 
     # Allow the puppet master to automatically sign certificates
-    put(StringIO('*'), '/etc/puppet/autosign.conf', use_sudo=True)
+    if env.get('loom_autosign') == 'true':
+        put(StringIO('*'), '/etc/puppet/autosign.conf', use_sudo=True)
+    else:
+        put(StringIO(''), '/etc/puppet/autosign.conf', use_sudo=True)
 
     # Upload Puppet configs
     upload_template(os.path.join(files_path, 'puppet/puppet.conf'), '/etc/puppet/puppet.conf', {

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -50,6 +50,8 @@ def update_configs():
     # Upload Puppet configs
     upload_template(os.path.join(files_path, 'puppet/puppet.conf'), '/etc/puppet/puppet.conf', {
         'server': get_puppetmaster_host() or '',
+        'certname': get_puppetmaster_host() or '',
+        'dns_alt_names': get_puppetmaster_host() or '',
         'environment': env.environment,
     }, use_sudo=True)
     put(os.path.join(files_path, 'puppet/auth.conf'), '/etc/puppet/auth.conf', use_sudo=True)


### PR DESCRIPTION
This pull request sets up puppet to automatically sign certificate requests and allows for a cert name that differs from the actual host name.

In this current form, automatically signing certificates is a security concern if the puppet master server has its control ports exposed to the world (which ours doesn't). I'll look into having loom make use of the roles defined in fabfile.py.
