### PR TITLE
Puppet & librarian-puppet version support

### DIFF
--- a/loom/files/puppet/hiera.yaml
+++ b/loom/files/puppet/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: /etc/puppet/hieradata
+:hierarchy:
+  - %{::clientcert}
+  - common

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -68,10 +68,15 @@ def install():
     with settings(hide('stdout'), show('running')):
         sudo('apt-get update')
     sudo('apt-get -y install rubygems git')
-    # librarian-puppet does not yet support 3.0.0
-    # https://github.com/rodjek/librarian-puppet/pull/37
-    sudo('gem install puppet -v 2.7.19 --no-ri --no-rdoc')
-    sudo('gem install librarian-puppet -v 0.9.6 --no-ri --no-rdoc')
+    # Version support for puppet & librarian-puppet
+    if env.get('loom_puppet_version'):
+        sudo('gem install puppet -v ' + env.get('loom_puppet_version') + ' --no-ri --no-rdoc')
+    else:
+        sudo('gem install puppet --no-ri --no-rdoc')
+    if env.get('loom_librarian_version'):
+        sudo('gem install librarian-puppet -v ' + env.get('loom_librarian_version') + ' --no-ri --no-rdoc')
+    else:
+        sudo('gem install librarian-puppet --no-ri --no-rdoc')
     # http://docs.puppetlabs.com/guides/installation.html
     sudo('puppet resource group puppet ensure=present')
     sudo("puppet resource user puppet ensure=present gid=puppet shell='/sbin/nologin'")

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -59,6 +59,9 @@ def update_configs():
         'environment': env.environment,
     }, use_sudo=True)
     put(os.path.join(files_path, 'puppet/auth.conf'), '/etc/puppet/auth.conf', use_sudo=True)
+    if not env.get('loom_puppet_version'):
+        put(os.path.join(files_path, 'puppet/hiera.yaml'), '/etc/puppet/hiera.yaml', use_sudo=True)
+
 
 @task
 def install():
@@ -71,14 +74,16 @@ def install():
     # Version support for puppet & librarian-puppet
     if env.get('loom_puppet_version'):
         sudo('gem install puppet -v ' + env.get('loom_puppet_version') + ' --no-ri --no-rdoc')
-        # Default hiera.yaml for puppet >3.0
-        put(os.path.join(files_path, 'puppet/hiera.yaml'), '/etc/puppet/hiera.yaml', use_sudo=True)
     else:
         sudo('gem install puppet --no-ri --no-rdoc')
+        # Default hiera.yaml for puppet >3.0
+        put(os.path.join(files_path, 'puppet/hiera.yaml'), '/etc/puppet/hiera.yaml', use_sudo=True)
+
     if env.get('loom_librarian_version'):
         sudo('gem install librarian-puppet -v ' + env.get('loom_librarian_version') + ' --no-ri --no-rdoc')
     else:
         sudo('gem install librarian-puppet --no-ri --no-rdoc')
+
     # http://docs.puppetlabs.com/guides/installation.html
     sudo('puppet resource group puppet ensure=present')
     sudo("puppet resource user puppet ensure=present gid=puppet shell='/sbin/nologin'")

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -71,6 +71,8 @@ def install():
     # Version support for puppet & librarian-puppet
     if env.get('loom_puppet_version'):
         sudo('gem install puppet -v ' + env.get('loom_puppet_version') + ' --no-ri --no-rdoc')
+        # Default hiera.yaml for puppet >3.0
+        put(os.path.join(files_path, 'puppet/hiera.yaml'), '/etc/puppet/hiera.yaml', use_sudo=True)
     else:
         sudo('gem install puppet --no-ri --no-rdoc')
     if env.get('loom_librarian_version'):

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -59,8 +59,7 @@ def update_configs():
         'environment': env.environment,
     }, use_sudo=True)
     put(os.path.join(files_path, 'puppet/auth.conf'), '/etc/puppet/auth.conf', use_sudo=True)
-    if not env.get('loom_puppet_version'):
-        put(os.path.join(files_path, 'puppet/hiera.yaml'), '/etc/puppet/hiera.yaml', use_sudo=True)
+    put(os.path.join(files_path, 'puppet/hiera.yaml'), '/etc/puppet/hiera.yaml', use_sudo=True)
 
 
 @task
@@ -76,8 +75,6 @@ def install():
         sudo('gem install puppet -v ' + env.get('loom_puppet_version') + ' --no-ri --no-rdoc')
     else:
         sudo('gem install puppet --no-ri --no-rdoc')
-        # Default hiera.yaml for puppet >3.0
-        put(os.path.join(files_path, 'puppet/hiera.yaml'), '/etc/puppet/hiera.yaml', use_sudo=True)
 
     if env.get('loom_librarian_version'):
         sudo('gem install librarian-puppet -v ' + env.get('loom_librarian_version') + ' --no-ri --no-rdoc')


### PR DESCRIPTION
These changes should be simple enough to merge. Upon going back to the base version of loom, the first thing I found I wanted back was the ability to specify specific versions of puppet and librarian-puppet.

Additionally, placed a default hiera.yaml file for puppet >=3.0 support.

To set a specific version, place the following in `fabfile.py`
    `env.loom_puppet_version = "2.7.19"`
    `env.loom_librarian_version = "0.9.6"`
