### PR TITLE
making version number follow PEP396

### DIFF
--- a/loom/__init__.py
+++ b/loom/__init__.py
@@ -1,3 +1,4 @@
+VERSION = (0, 0, 8)
+__version__ = ".".join([str(x) for x in VERSION])
 # ensure env variables are set first before overrides
 from . import config
-

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,11 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup
+from loom import __version__ as version
 
 setup(
     name='loom',
-    version='0.0.8',
+    version=version,
     description='Elegant deployment with Fabric and Puppet.',
     author='Ben Firshman',
     author_email='ben@firshman.co.uk',
@@ -15,4 +16,3 @@ setup(
     install_requires = open('requirements.txt').readlines(),
     #test_suite = 'nose.collector',
 )
-


### PR DESCRIPTION
I would like to have this to be able to generate version numbers for CI nightly builds as I plan on using this a bunch on other projects.
