### PR TITLE
Helper methods to check for installation of Librarian

### DIFF
--- a/loom/config.py
+++ b/loom/config.py
@@ -31,3 +31,7 @@ def has_puppet_installed():
     return result.succeeded
 
 
+def has_librarian_installed():
+    with settings(hide('warnings', 'running', 'stdout', 'stderr'), warn_only=True):
+        librarian = run('which librarian-puppet')
+    return librarian.succeeded

--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -2,7 +2,7 @@ from fabric.api import env, abort, put, cd, sudo, task, settings, hide, show, ex
 from fabric.contrib.files import upload_template
 from StringIO import StringIO
 import os
-from .config import current_roles, has_puppet_installed
+from .config import current_roles, has_puppet_installed, has_librarian_installed
 from .tasks import restart
 from .utils import upload_dir
 
@@ -34,6 +34,8 @@ def update():
         abort('Host "%s" has no roles. Does it exist in this environment?' % env.host_string)
     if not has_puppet_installed():
         abort('Host "%s" does not have puppet installed. Try "fab puppet.install".' % env.host_string)
+    if not has_librarian_installed():
+        abort('Host "%s" does not have librarian-puppet installed. Try "fab puppet.install".' % env.host_string)
 
     # Install local modules
     module_dir = env.get('puppet_module_dir', 'modules/')


### PR DESCRIPTION
Some vagrant boxes have puppet but not librarian. In the future, we may want to check for specific versions, but for now, I'm happy with this.
