### PR TITLE
loom/puppet.py - Ubuntu 14.04 'rubygems' becomes 'ruby', handle error

### DIFF
--- a/loom/puppet.py
+++ b/loom/puppet.py
@@ -1,4 +1,4 @@
-from fabric.api import env, abort, put, cd, sudo, task, execute
+from fabric.api import env, abort, put, cd, sudo, task, execute, settings
 from fabric.contrib.files import upload_template
 from StringIO import StringIO
 import os
@@ -81,7 +81,9 @@ def install():
     Install Puppet and its configs without any agent or master.
     """
     sudo('apt-get update -qq')
-    sudo('apt-get -y -q install rubygems git')
+    with settings(warn_only=True):
+        sudo('apt-get -y -q install rubygems')
+    sudo('apt-get -y -q install ruby ruby-dev git')
 
     puppet_version = env.get('loom_puppet_version')
     sudo(_gem_install('puppet', version=puppet_version))


### PR DESCRIPTION
Starting with at most Ubuntu 14.04 rubygems has become ruby. Attempting
to install rubygems results in an error that suggests re-installing
as ruby. I'm pretty sure this must have changed in a previous Ubuntu
version, since 14.04 is just an LTS cut of some previous version.

Rather than detect return codes I just use a context manager to
aggressively attempt to install rubygems and ruby. This results in
some cruft to stdout but is easier to understand than conditional
processing based on return codes.
