### PR TITLE
hiera.yaml - remove non-compliant line

### DIFF
--- a/loom/files/puppet/hiera.yaml
+++ b/loom/files/puppet/hiera.yaml
@@ -4,5 +4,4 @@
 :yaml:
   :datadir: /etc/puppet/hieradata
 :hierarchy:
-  - %{::clientcert}
   - common


### PR DESCRIPTION
On both Fedora 18+ and Ubuntu 13.10+, whilst using Puppet 3.6.2, the
clientcert line in hiera.yaml prevents loom from working. Specifically
the error message that appears is:

```
[192.168.50.10] out: Error: Error from DataBinding 'hiera' while looking
up 'sudo::enable': (<unknown>): found character that cannot start any
token while scanning for the next token at line 7 column 5 on node
ubuntu-14.04-amd64-vbox
[192.168.50.10] out: Wrapped exception:
[192.168.50.10] out: (<unknown>): found character that cannot start any
token while scanning for the next token at line 7 column 5
[192.168.50.10] out: Wrapped exception:
[192.168.50.10] out: (<unknown>): found character that cannot start any
token while scanning for the next token at line 7 column 5
[192.168.50.10] out: Error: Error from DataBinding 'hiera' while looking
up 'sudo::enable': (<unknown>): found character that cannot start any
token while scanning for the next token at line 7 column 5 on node
ubuntu-14.04-amd64-vbox
[192.168.50.10] out:
```

It is possible that I have misconfigured my Puppet manifests and that is
causing this error. However removing the `%{::clientcert}` line from
`hiera.yaml` does not seem to have any negative consequences.

If you'd like a better, more minimal reproduction of this issue please let
me know; I have some Vagrant/Puppet scripts lying around.
