### PR TITLE
.travis.yml - fix pspec->Attest->progressbar dependency installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-before_script: pip install -r dev-requirements.txt
+before_script: pip install -r dev-requirements.txt --allow-external progressbar --allow-unverified progressbar
 script: script/test
 deploy: 
   provider: pypi


### PR DESCRIPTION
(WORK IN PROGRESS, first check that the Travis build passes)

In order to install progressbar we need to explicitly permit pip to
install external and unverified packages. Without this commit the Travis
build fails. This is likely linked to Travis updating their version of
pip to a version that now requires this behavior to be explicitly
permitted.
